### PR TITLE
fix: add the max gas limit when bumping estimated gas

### DIFF
--- a/types.go
+++ b/types.go
@@ -183,6 +183,7 @@ type LsConfig struct {
 	// if number of tasks reaches this number, it waits until this number decrease
 	MaxProcessingTasks int    `json:"maxProcessingTasks" mapstructure:"maxProcessingTasks"`
 	GasLimitBumpRatio  uint64 `json:"gasLimitBumpRatio" mapstructure:"gasLimitBumpRatio"`
+	MaxBulkTasks       int    `json:"maxBulkTasks" mapstructure:"maxBulkTasks"`
 
 	Stats *ListenerStats `json:"stats" mapstructure:"stats"`
 }

--- a/utils/main.go
+++ b/utils/main.go
@@ -27,7 +27,10 @@ import (
 	"golang.org/x/text/language"
 )
 
-const Percentage = 100
+const (
+	Percentage  = 100
+	maxGasLimit = 50_000_000
+)
 
 // hasherPool holds LegacyKeccak256 hashers for rlpHash.
 var hasherPool = sync.Pool{
@@ -200,6 +203,9 @@ func (u *utils) SendContractTransaction(
 
 	opts.NoSend = false
 	opts.GasLimit = tx.Gas() * gasLimitBumpRatio / Percentage
+	if opts.GasLimit > maxGasLimit {
+		opts.GasLimit = maxGasLimit
+	}
 	return fn(opts)
 }
 


### PR DESCRIPTION
Currently, with our gas price and default RPC configuration, transaction with gas more than 50_000_000 is not accepted. This commit avoids bumping the estimated gas limit above 50_000_000.